### PR TITLE
[Sync] Update project files from source repository (674fd70)

### DIFF
--- a/.github/actions/cache-redis-image/action.yml
+++ b/.github/actions/cache-redis-image/action.yml
@@ -126,7 +126,7 @@ runs:
     - name: 💾 Restore Redis image from cache
       if: contains(inputs.cache-mode, 'restore')
       id: restore-redis-image
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache/restore@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
       with:
         path: ${{ steps.cache-config.outputs.cache-path }}
         key: ${{ steps.cache-config.outputs.cache-key }}
@@ -222,7 +222,7 @@ runs:
     # --------------------------------------------------------------------
     - name: 🗄️ Save Redis image cache
       if: contains(inputs.cache-mode, 'save') && steps.save-redis-image.outputs.image-saved == 'true' && steps.restore-redis-image.outputs.cache-hit != 'true'
-      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache/save@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
       with:
         path: ${{ steps.cache-config.outputs.cache-path }}
         key: ${{ steps.cache-config.outputs.cache-key }}

--- a/.github/actions/setup-benchstat/action.yml
+++ b/.github/actions/setup-benchstat/action.yml
@@ -87,7 +87,7 @@ runs:
     - name: 💾 Restore benchstat binary cache
       if: steps.version-check.outputs.skip != 'true'
       id: benchstat-cache
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
       with:
         path: ~/.cache/benchstat-bin
         key: ${{ inputs.runner-os }}-benchstat-${{ inputs.benchstat-version }}

--- a/.github/actions/setup-go-with-cache/action.yml
+++ b/.github/actions/setup-go-with-cache/action.yml
@@ -215,7 +215,7 @@ runs:
     # --------------------------------------------------------------------
     - name: 💾 Go module cache
       id: restore-gomod
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
       with:
         path: ~/go/pkg/mod
         key: ${{ steps.cache-keys.outputs.module-key }}
@@ -289,7 +289,7 @@ runs:
     # --------------------------------------------------------------------
     - name: 💾 Go build cache
       id: restore-gobuild
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
       with:
         path: |
           ~/.cache/go-build
@@ -442,7 +442,7 @@ runs:
     # --------------------------------------------------------------------
     - name: 🏗️ Set up Go
       id: setup-go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ inputs.go-version }}
         cache: false # we handle caches ourselves

--- a/.github/actions/setup-goreleaser/action.yml
+++ b/.github/actions/setup-goreleaser/action.yml
@@ -72,7 +72,7 @@ runs:
     - name: 💾 Restore goreleaser binary cache
       id: goreleaser-cache
       if: steps.check-existing.outputs.exists != 'true'
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
       with:
         path: |
           ~/.cache/goreleaser-bin

--- a/.github/actions/setup-mage/action.yml
+++ b/.github/actions/setup-mage/action.yml
@@ -47,7 +47,7 @@ runs:
     # --------------------------------------------------------------------
     - name: 💾 Restore mage binary cache
       id: mage-cache
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
       with:
         path: ~/.cache/mage-bin
         key: ${{ inputs.runner-os }}-mage-${{ inputs.mage-version }}

--- a/.github/actions/setup-magex/action.yml
+++ b/.github/actions/setup-magex/action.yml
@@ -53,7 +53,7 @@ runs:
     - name: 💾 Restore magex binary cache
       id: magex-cache
       if: inputs.use-local != 'true'
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
       with:
         path: |
           ~/.cache/magex-bin
@@ -82,7 +82,7 @@ runs:
     - name: 💾 Restore magex binary cache (local)
       id: magex-local-cache
       if: inputs.use-local == 'true'
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
       with:
         path: |
           ~/.cache/magex-local

--- a/.github/actions/warm-cache/action.yml
+++ b/.github/actions/warm-cache/action.yml
@@ -369,7 +369,7 @@ runs:
     # ────────────────────────────────────────────────────────────────────────────
     - name: 💾 Save Go build cache
       if: steps.setup-go.outputs.build-cache-hit != 'true'
-      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache/save@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
       with:
         path: |
           ~/.cache/go-build
@@ -381,7 +381,7 @@ runs:
     # ────────────────────────────────────────────────────────────────────────────
     - name: 💾 Save Go module cache
       if: steps.setup-go.outputs.module-cache-hit != 'true'
-      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache/save@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
       with:
         path: ~/go/pkg/mod
         key: ${{ steps.cache-keys.outputs.module-key }}


### PR DESCRIPTION
## What Changed

* Updated `actions/cache` from `v5.0.5` (commit `27d5ce7f107fe9357f9df03efb73ab90386fccae`) to `v6.0.0` (commit `2c8a9bd7457de244a408f35966fab2fb45fda9c8`) across multiple workflow action files
* Updated `actions/cache/restore` from `v5.0.5` to `v6.0.0` in cache-redis-image action
* Updated `actions/cache/save` from `v5.0.5` to `v6.0.0` in warm-cache and cache-redis-image actions
* Updated `actions/setup-go` from `v6.4.0` (commit `4a3601121dd01d1626a1e23e37211e3254c1c06c`) to `v6.5.0` (commit `924ae3a1cded613372ab5595356fb5720e22ba16`) in setup-go-with-cache action

## Why It Was Necessary

* Ensures GitHub Actions dependencies are kept up-to-date with the latest stable releases
* Provides access to bug fixes, security patches, and performance improvements included in the newer versions
* Maintains consistency across all caching operations by upgrading all cache-related actions to the same major version

## Testing Performed

* CI workflows should be monitored on the next run to verify successful execution with updated actions
* All caching operations (Go modules, Go build cache, benchstat binary, Redis images, goreleaser binary, mage binary, and magex binary) should be validated
* Verify cache restoration and saving continue to function correctly across all affected workflows

## Impact / Risk

* **Low Risk**: Minor version updates for setup-go (v6.4.0 → v6.5.0) and major version update for cache actions (v5 → v6) are expected to be backwards compatible
* **No Breaking Changes**: These are GitHub Actions dependency updates that should not affect application code or runtime behavior
* **CI Impact**: Potential for temporary CI failures if new action versions introduce unexpected behavior, but can be quickly reverted by rolling back commit hashes

<!-- go-broadcast-metadata
group:
  id: mrz-projects-public
  name: mrz-projects-public
diff_info:
  staged_repo_available: true
  changed_files_count: 7
  files_with_original_content: 7
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: 674fd707e89e9a9b2dd9bea4d8f1eb14f84b85e6
  target_repo: mrz1836/go-lucky
  sync_commit: 7019eb32dfa96e62cc35cdec8c7dc8cc7c5eafeb
  sync_time: 2026-06-24T20:24:43-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 262
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 7
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 1248
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 241
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 0
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 592
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 431
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 1135
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 1850
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 587
performance:
  total_files: 103
-->
